### PR TITLE
Making mongo-storm compatibile with Storm 0.7.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,5 +9,5 @@
                    :random (fn [_] (> (rand) ~(float 1/2)))
                    :all (constantly true)}
   :dependencies [[redis.clients/jedis "2.0.0"] [org.mongodb/mongo-java-driver "2.7.3"]]
-  :dev-dependencies [[storm "0.6.2"] [clojure "1.2.1"] [clojure-contrib "1.2.0"] [junit "4.10"]])
+  :dev-dependencies [[storm "0.7.0"] [clojure "1.2.1"] [clojure-contrib "1.2.0"] [junit "4.10"]])
 

--- a/src/jvm/org/mongodb/bolt/MongoBoltBase.java
+++ b/src/jvm/org/mongodb/bolt/MongoBoltBase.java
@@ -2,7 +2,7 @@ package org.mongodb.bolt;
 
 import backtype.storm.task.OutputCollector;
 import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.IRichBolt;
+import backtype.storm.topology.base.BaseRichBolt;
 import backtype.storm.topology.OutputFieldsDeclarer;
 import backtype.storm.tuple.Tuple;
 import com.mongodb.*;
@@ -12,7 +12,7 @@ import org.mongodb.StormMongoObjectGrabber;
 import java.net.UnknownHostException;
 import java.util.Map;
 
-public abstract class MongoBoltBase implements IRichBolt {
+public abstract class MongoBoltBase extends BaseRichBolt {
     static Logger LOG = Logger.getLogger(MongoBoltBase.class);
 
     // Bolt runtime objects

--- a/src/jvm/org/mongodb/spout/MongoSpoutBase.java
+++ b/src/jvm/org/mongodb/spout/MongoSpoutBase.java
@@ -2,7 +2,7 @@ package org.mongodb.spout;
 
 import backtype.storm.spout.SpoutOutputCollector;
 import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.IRichSpout;
+import backtype.storm.topology.base.BaseRichSpout;
 import backtype.storm.topology.OutputFieldsDeclarer;
 import backtype.storm.tuple.Fields;
 import com.mongodb.DB;
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 
-public abstract class MongoSpoutBase implements IRichSpout {
+public abstract class MongoSpoutBase extends BaseRichSpout {
     static Logger LOG = Logger.getLogger(MongoSpoutBase.class);
 
     protected static MongoObjectGrabber wholeDocumentMapper = null;
@@ -64,11 +64,6 @@ public abstract class MongoSpoutBase implements IRichSpout {
         this.collectionNames = collectionNames;
         this.query = query;
         this.mapper = mapper == null ? wholeDocumentMapper : mapper;
-    }
-
-    @Override
-    public boolean isDistributed() {
-        return false;
     }
 
     @Override


### PR DESCRIPTION
Hi Christian, 

I'm working on Storm/Mongo project and I need to use Storm 0.7.0 

I forked your project and modified MongoBoltBase and MongoSpoutBase according to: 
http://groups.google.com/group/storm-user/browse_thread/thread/676e1891ad35572c

I compiled the project and I was able to run my Storm 0.7.0 topology successfully using the modified code.

Please feel free to review my changes and if you see them good, I will be more than happy to feel "contributing" :)

Thanks for creating this project.

Greetings,
Hussein.
